### PR TITLE
Shadow images should not be fuzzy on Retina devices

### DIFF
--- a/Classes/UIImage+HTButton.m
+++ b/Classes/UIImage+HTButton.m
@@ -134,7 +134,7 @@
     //Round the image above according to cornerRadius
     UIImageView *imageView = [[UIImageView alloc] initWithImage:image];
     
-    UIGraphicsBeginImageContextWithOptions(imageView.bounds.size, NO, 1.0);
+    UIGraphicsBeginImageContextWithOptions(imageView.bounds.size, NO, 0);
     [[UIBezierPath bezierPathWithRoundedRect:imageView.bounds
                                 cornerRadius:cornerRadius] addClip];
     [image drawInRect:imageView.bounds];


### PR DESCRIPTION
UIGraphicsBeginImageContextWithOptions should be passed in 0 for scale
in order to use the current system scale.
