### PR TITLE
Prefix category methods.

### DIFF
--- a/Classes/HTPressableButton.m
+++ b/Classes/HTPressableButton.m
@@ -143,33 +143,33 @@
     }
     if (isButtoncircular)
     {
-        buttonNormal = [UIImage circularButtonWithColor:_buttonColor
-                                              andSize:self.frame.size
-                                      andShadowHeight:_shadowHeight
-                                       andShadowColor:_shadowColor
-                                      andCornerRadius:_cornerRadius];
+        buttonNormal = [UIImage ht_circularButtonWithColor:_buttonColor
+                                              size:self.frame.size
+                                      shadowHeight:_shadowHeight
+                                       shadowColor:_shadowColor
+                                      cornerRadius:_cornerRadius];
         
-        buttonHighlighted = [UIImage circularButtonWithHighlightedColor:_buttonColor
-                                                              andSize:self.frame.size
-                                                      andShadowHeight:_shadowHeight
-                                                       andShadowColor:_shadowColor
-                                                      andCornerRadius:_cornerRadius];
-        buttonDisabled = [UIImage circularButtonWithColor:[UIColor mediumColor] andSize:self.frame.size andShadowHeight:_shadowHeight andShadowColor:[UIColor mediumDarkColor] andCornerRadius:_cornerRadius];
+        buttonHighlighted = [UIImage ht_circularButtonWithHighlightedColor:_buttonColor
+                                                              size:self.frame.size
+                                                      shadowHeight:_shadowHeight
+                                                       shadowColor:_shadowColor
+                                                      cornerRadius:_cornerRadius];
+        buttonDisabled = [UIImage ht_circularButtonWithColor:[UIColor mediumColor] size:self.frame.size shadowHeight:_shadowHeight shadowColor:[UIColor mediumDarkColor] cornerRadius:_cornerRadius];
     }
     else
     {
         // Rectangular or rounded-corner buttons
-        buttonNormal = [UIImage buttonWithColor:_buttonColor
-                                        andSize:self.frame.size
-                                andShadowHeight:_shadowHeight
-                                 andShadowColor:_shadowColor
-                                andCornerRadius:_cornerRadius];
+        buttonNormal = [UIImage ht_buttonWithColor:_buttonColor
+                                        size:self.frame.size
+                                shadowHeight:_shadowHeight
+                                 shadowColor:_shadowColor
+                                cornerRadius:_cornerRadius];
         
-        buttonHighlighted = [UIImage buttonWithHighlightedColor:_buttonColor
-                                                        andSize:self.frame.size
-                                                andShadowHeight:_shadowHeight
-                                                 andShadowColor:_shadowColor
-                                                andCornerRadius:_cornerRadius];
+        buttonHighlighted = [UIImage ht_buttonWithHighlightedColor:_buttonColor
+                                                        size:self.frame.size
+                                                shadowHeight:_shadowHeight
+                                                 chadowColor:_shadowColor
+                                                cornerRadius:_cornerRadius];
     }
     
     [self setBackgroundImage:buttonNormal forState:UIControlStateNormal];

--- a/Classes/UIImage+HTButton.h
+++ b/Classes/UIImage+HTButton.h
@@ -22,11 +22,11 @@
  @param shadowColor The background color of the shadow
  @param cornerRadius The corner radius of the button
  */
-+ (UIImage *) buttonWithColor: (UIColor *) buttonColor
-                      andSize: (CGSize) size
-              andShadowHeight: (CGFloat) shadowHeight
-               andShadowColor: (UIColor *) shadowColor
-              andCornerRadius: (CGFloat) cornerRadius;
++ (UIImage *) ht_buttonWithColor: (UIColor *) buttonColor
+                            size: (CGSize) size
+                    shadowHeight: (CGFloat) shadowHeight
+                     shadowColor: (UIColor *) shadowColor
+                    cornerRadius: (CGFloat) cornerRadius;
 
 /**
  Create a composite image to be used as the highlighted state of a button
@@ -36,11 +36,11 @@
  @param shadowColor The background color of the shadow
  @param cornerRadius The corner radius of the button
  */
-+ (UIImage *) buttonWithHighlightedColor: (UIColor *) buttonColor
-                                 andSize: (CGSize) size
-                         andShadowHeight: (CGFloat) shadowHeight
-                          andShadowColor: (UIColor *) shadowColor
-                         andCornerRadius: (CGFloat) cornerRadius;
++ (UIImage *) ht_buttonWithHighlightedColor: (UIColor *) buttonColor
+                                       size: (CGSize) size
+                               shadowHeight: (CGFloat) shadowHeight
+                                chadowColor: (UIColor *) shadowColor
+                               cornerRadius: (CGFloat) cornerRadius;
 
 /**
  Create a composite circular image to be used as the button background
@@ -50,11 +50,11 @@
  @param shadowColor The background color of the shadow
  @param cornerRadius The corner radius of the button
  */
-+ (UIImage *) circularButtonWithColor: (UIColor *) buttonColor
-                            andSize: (CGSize) size
-                    andShadowHeight: (CGFloat) shadowHeight
-                     andShadowColor: (UIColor *) shadowColor
-                    andCornerRadius: (CGFloat) cornerRadius;
++ (UIImage *) ht_circularButtonWithColor: (UIColor *) buttonColor
+                                    size: (CGSize) size
+                            shadowHeight: (CGFloat) shadowHeight
+                             shadowColor: (UIColor *) shadowColor
+                            cornerRadius: (CGFloat) cornerRadius;
 
 /**
  Create a composite circular image to be used as the highlighted state of a button
@@ -64,11 +64,11 @@
  @param shadowColor The background color of the shadow
  @param cornerRadius The corner radius of the button
  */
-+ (UIImage *) circularButtonWithHighlightedColor: (UIColor *) buttonColor
-                                       andSize: (CGSize) size
-                               andShadowHeight: (CGFloat) shadowHeight
-                                andShadowColor: (UIColor *) shadowColor
-                               andCornerRadius:(CGFloat) cornerRadius;
++ (UIImage *) ht_circularButtonWithHighlightedColor: (UIColor *) buttonColor
+                                               size: (CGSize) size
+                                       shadowHeight: (CGFloat) shadowHeight
+                                        shadowColor: (UIColor *) shadowColor
+                                       cornerRadius: (CGFloat) cornerRadius;
 
 /**
  Create a new image filled with a color
@@ -76,8 +76,8 @@
  @param size The size of the image
  @param cornerRadius The corner radius of the image
  */
-+ (UIImage *) imageWithColor: (UIColor *) color
-                     andSize: (CGSize) size
-             andCornerRadius: (CGFloat) cornerRadius;
++ (UIImage *) ht_imageWithColor: (UIColor *) color
+                           size: (CGSize) size
+                   cornerRadius: (CGFloat) cornerRadius;
 
 @end

--- a/Classes/UIImage+HTButton.m
+++ b/Classes/UIImage+HTButton.m
@@ -11,18 +11,18 @@
 
 @implementation UIImage (HTButton)
 
-+ (UIImage *) buttonWithColor: (UIColor *) buttonColor
-                      andSize: (CGSize) size
-              andShadowHeight: (CGFloat) shadowHeight
-               andShadowColor: (UIColor *) shadowColor
-              andCornerRadius: (CGFloat) cornerRadius
++ (UIImage *) ht_buttonWithColor: (UIColor *) buttonColor
+                            size: (CGSize) size
+                    shadowHeight: (CGFloat) shadowHeight
+                     shadowColor: (UIColor *) shadowColor
+                    cornerRadius: (CGFloat) cornerRadius
 {
     UIImage *buttonImage;
     
     //button color
-    UIImage *frontImage = [UIImage imageWithColor:buttonColor andSize:size andCornerRadius:cornerRadius];
+    UIImage *frontImage = [UIImage ht_imageWithColor:buttonColor size:size cornerRadius:cornerRadius];
     //button's shadow color
-    UIImage *backImage = [UIImage imageWithColor:shadowColor andSize:size andCornerRadius:cornerRadius];
+    UIImage *backImage = [UIImage ht_imageWithColor:shadowColor size:size cornerRadius:cornerRadius];
 
     CGRect rect = CGRectMake(0, 0, backImage.size.width, backImage.size.height + shadowHeight);
     
@@ -36,16 +36,16 @@
     return buttonImage;
 }
 
-+ (UIImage *) buttonWithHighlightedColor: (UIColor *) buttonColor
-                                 andSize: (CGSize) size
-                         andShadowHeight: (CGFloat) shadowHeight
-                          andShadowColor: (UIColor *) shadowColor
-                         andCornerRadius: (CGFloat) cornerRadius
++ (UIImage *) ht_buttonWithHighlightedColor: (UIColor *) buttonColor
+                                       size: (CGSize) size
+                               shadowHeight: (CGFloat) shadowHeight
+                                chadowColor: (UIColor *) shadowColor
+                               cornerRadius: (CGFloat) cornerRadius
 {
     UIImage *buttonHighlightedImage;
     
-    UIImage *frontImage = [UIImage imageWithColor:buttonColor andSize:size andCornerRadius:cornerRadius];
-    UIImage *backImage = [UIImage imageWithColor:shadowColor andSize:size andCornerRadius:cornerRadius];
+    UIImage *frontImage = [UIImage ht_imageWithColor:buttonColor size:size cornerRadius:cornerRadius];
+    UIImage *backImage = [UIImage ht_imageWithColor:shadowColor size:size cornerRadius:cornerRadius];
     
     CGRect rect = CGRectMake(0, 0, frontImage.size.width, frontImage.size.height + shadowHeight);
     
@@ -61,16 +61,16 @@
     
 }
 
-+ (UIImage *) circularButtonWithColor: (UIColor *) buttonColor
-                            andSize: (CGSize) size
-                    andShadowHeight: (CGFloat) shadowHeight
-                     andShadowColor: (UIColor *) shadowColor
-                    andCornerRadius: (CGFloat) cornerRadius
++ (UIImage *) ht_circularButtonWithColor: (UIColor *) buttonColor
+                                    size: (CGSize) size
+                            shadowHeight: (CGFloat) shadowHeight
+                             shadowColor: (UIColor *) shadowColor
+                            cornerRadius: (CGFloat) cornerRadius
 {
     UIImage *buttonImage;
     
-    UIImage *frontImage = [UIImage imageWithColor:buttonColor andSize:size andCornerRadius:cornerRadius];
-    UIImage *backImage = [UIImage imageWithColor:shadowColor andSize:size andCornerRadius:cornerRadius];
+    UIImage *frontImage = [UIImage ht_imageWithColor:buttonColor size:size cornerRadius:cornerRadius];
+    UIImage *backImage = [UIImage ht_imageWithColor:shadowColor size:size cornerRadius:cornerRadius];
     
     //Make the rectangular a little bigger than the button
     CGRect rect = CGRectMake(0,
@@ -88,16 +88,16 @@
     return buttonImage;
 }
 
-+ (UIImage *) circularButtonWithHighlightedColor: (UIColor *) buttonColor
-                                       andSize: (CGSize) size
-                               andShadowHeight: (CGFloat) shadowHeight
-                                andShadowColor: (UIColor *) shadowColor
-                               andCornerRadius: (CGFloat) cornerRadius
++ (UIImage *) ht_circularButtonWithHighlightedColor: (UIColor *) buttonColor
+                                               size: (CGSize) size
+                                       shadowHeight: (CGFloat) shadowHeight
+                                        shadowColor: (UIColor *) shadowColor
+                                       cornerRadius: (CGFloat) cornerRadius
 {
     UIImage *buttonHighlightedImage;
     
-    UIImage *frontImage = [UIImage imageWithColor:buttonColor andSize:size andCornerRadius:cornerRadius];
-    UIImage *backImage = [UIImage imageWithColor:shadowColor andSize:size andCornerRadius:cornerRadius];
+    UIImage *frontImage = [UIImage ht_imageWithColor:buttonColor size:size cornerRadius:cornerRadius];
+    UIImage *backImage = [UIImage ht_imageWithColor:shadowColor size:size cornerRadius:cornerRadius];
     
     CGRect rect = CGRectMake(0,
                              0,
@@ -116,9 +116,9 @@
 }
 
 
-+ (UIImage *) imageWithColor: (UIColor *) color
-                     andSize: (CGSize) size
-             andCornerRadius: (CGFloat) cornerRadius
++ (UIImage *) ht_imageWithColor: (UIColor *) color
+                           size: (CGSize) size
+                   cornerRadius: (CGFloat) cornerRadius
 {
     //Draw the image according to the size and color
     CGRect rect = CGRectMake(0, 0, size.width, size.height);


### PR DESCRIPTION
In Objective-C, we usually prefix our category methods as a namespace to avoid the method implementation collision. 
