### PR TITLE
Add a subspec for HTColor

### DIFF
--- a/HTPressableButton.podspec
+++ b/HTPressableButton.podspec
@@ -8,7 +8,16 @@ Pod::Spec.new do |s|
   s.authors            = { "He Rin Kim" => "me@herinkim.com", "Thanakron Tandavas" => "thanakron@tandavas.com" }
   s.screenshot  = "https://dl.dropboxusercontent.com/s/na4sowpi58dcajv/HTPressableButtonImage.gif"
   s.platform     = :ios, '6.0' 
-  s.source       = { :git => "https://github.com/herinkc/HTPressableButton.git", :tag => :"1.1.0" }
-  s.source_files  = 'Classes', 'Classes/**/*.{h,m}'
+  s.source       = { :git => "https://github.com/herinkc/HTPressableButton.git", :tag => s.version }
   s.requires_arc = true
+  s.default_subspec = "All"
+
+  s.subspec "All" do |all|
+    all.source_files  = 'Classes', 'Classes/**/*.{h,m}'
+  end
+
+  s.subspec "HTColor" do |color|
+    color.source_files = "Classes/UIColor+HTColor.{h,m}"
+  end
+
 end


### PR DESCRIPTION
- Use standalone `UIColor+HTColor` by specifying `pod 'HTPressableButton/HTColor'`
- The usage of `pod 'HTPressableButton'` remains the same

Thanks for creating the category of color scheme. It's really handy!
